### PR TITLE
[MRG] Add documentation details to bring repository closer to open-source standard

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+Thanks for contributing. If this is your first time,
+make sure to read [contributing document](https://github.com/cronelab/ReconstructionVisualizer/master/doc/contribute.rst)
+
+PR Description
+--------------
+
+Describe your PR here
+
+Merge checklist
+---------------
+
+Maintainer, please confirm the following before merging:
+
+- [ ] All comments resolved
+- [ ] This is not your own PR
+- [ ] All CIs are happy
+- [ ] PR title starts with [MRG]
+- [ ] [whats_new.rst](https://github.com/cronelab/ReconstructionVisualizer/master/doc/whats_new.rst) is updated
+- [ ] PR description includes phrase "closes <#issue-number>"
+- [ ] Commit history does not contain any merge commits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributions
+
+Contributions are welcome in the form of pull requests.
+
+Once the implementation of a piece of functionality is considered to be bug
+free and properly documented (both API docs and an example script),
+it can be incorporated into the master branch.
+
+To help developing `seek` or `ReconstructionVisualizer`, you will need a few adjustments to your
+installation as shown below.
+
+## Running tests
+
+### (Optional) Install Docker
+To run workflows, it is recommended to use Docker. Install Docker at: https://docs.docker.com/get-docker/.
+
+### Install development version of seek
+First, you should [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the `seek` repository. 
+Then, clone the fork and install it in.
+
+TODO insert how to install and setup, or link to instructions.
+
+### Install development version of ReconstructionVisualizer
+First, you should [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the 
+`ReconstructionVisualizer` repository. Then, clone the fork and install it.
+
+TODO insert how to install and setup, or link to instructions.
+
+### Install Python packages required to run tests
+Install the following packages for testing purposes, plus all optonal MNE-BIDS
+dependencies to ensure you will be able to run all tests.
+
+    $ pip install flake8 pytest pytest-cov
+
+### Install the BIDS validator
+Finally, it is necessary to install the
+[BIDS validator](https://github.com/bids-standard/bids-validator). The outputs
+of MNE-BIDS are run through the BIDS validator to check if the conversion
+worked properly and produced datasets that conforms to the BIDS specifications.
+
+You will need the `command line version` of the validator.
+
+#### Global (system-wide) installation
+- First, install [Node.js](https://nodejs.org/en/).
+- For installing the **stable** version of `bids-validator`, please follow the
+instructions as detailed in the README of the bids-validator repository.
+- For installing the **development** version of `bids-validator`, see [here](https://github.com/bids-standard/bids-validator/blob/master/CONTRIBUTING.md#using-the-development-version-of-bids-validator).
+
+Test your installation by running:
+
+    $ bids-validator --version
+
+#### Local (per-user) development installation
+
+Install [Node.js](https://nodejs.org/en/). If you're use `conda`, you can
+install the `nodejs` package from `conda-forge` by running
+`conda install -c conda-forge nodejs`.
+
+Then, retrieve the validator and install all its dependencies via `npm`.
+
+    $ git clone git@github.com:bids-standard bids-validator.git
+    $ cd bids-validator/bids-validator
+    $ npm i
+
+Test your installation by running:
+
+    $ ./bin/bids-validator --version
+
+## Building the documentation
+
+TODO: @Christopher Coogan, can you help fill this in?
+
+The documentation can be built using sphinx. For that, please additionally
+install the following:
+
+    $ pip install matplotlib nilearn sphinx numpydoc sphinx-gallery sphinx_bootstrap_theme pillow
+
+To build the documentation locally, one can run:
+
+    $ cd doc/
+    $ make html
+
+or
+
+    $ make html-noplot
+    
+if you don't want to run the examples to build the documentation. This will result in a faster build but produce no plots in the examples.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,11 +26,40 @@ First, you should [fork](https://help.github.com/en/github/getting-started-with-
 
 TODO insert how to install and setup, or link to instructions.
 
-### Install Python packages required to run tests
+### Install Python/javascript packages required to run tests
 Install the following packages for testing purposes, plus all optonal MNE-BIDS
 dependencies to ensure you will be able to run all tests.
 
     $ pip install flake8 pytest pytest-cov
+
+Running code linter:
+
+    TODO: @Christopher can you add how you can code lint the javascript code?
+
+
+## Building the documentation
+
+TODO: @Christopher Coogan, can you help fill this in?
+
+The documentation can be built using sphinx. For that, please additionally
+install the following:
+
+    $ pip install matplotlib nilearn sphinx numpydoc sphinx-gallery sphinx_bootstrap_theme pillow
+
+To build the documentation locally, one can run:
+
+    $ cd doc/
+    $ make html
+
+or
+
+    $ make html-noplot
+    
+if you don't want to run the examples to build the documentation. This will result in a faster build but produce no plots in the examples.
+
+## BIDS-Validation
+To robustly apply seek workflows and reconstruction visualiztion, we rely on the BIDS specification 
+for storing data. One can use the `bids-validator` to verify that a dataset is BIDS-compliant.
 
 ### Install the BIDS validator
 Finally, it is necessary to install the
@@ -65,23 +94,3 @@ Then, retrieve the validator and install all its dependencies via `npm`.
 Test your installation by running:
 
     $ ./bin/bids-validator --version
-
-## Building the documentation
-
-TODO: @Christopher Coogan, can you help fill this in?
-
-The documentation can be built using sphinx. For that, please additionally
-install the following:
-
-    $ pip install matplotlib nilearn sphinx numpydoc sphinx-gallery sphinx_bootstrap_theme pillow
-
-To build the documentation locally, one can run:
-
-    $ cd doc/
-    $ make html
-
-or
-
-    $ make html-noplot
-    
-if you don't want to run the examples to build the documentation. This will result in a faster build but produce no plots in the examples.

--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ The gLTF binary file format allows for optimized viewing directly in browsers an
 - Electrodes
     - electrodeGroupA
         - electrodeGroupA1
+
+Citing
+------
+TODO

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -1,0 +1,2 @@
+.. _Adam Li: https://github.com/adam2392
+.. _Christopher Coogan: https://github.com/TheBrainChain

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -1,0 +1,30 @@
+:orphan:
+
+Contributing to SEEK and ReconstructionVisualizer
+=================================================
+
+SEEK and ReconstructionVisualizer is an open-source software project developed through community effort.
+You are very welcome to participate in the development by reporting bugs,
+writing documentation, or contributing code.
+
+Development takes place on the collaborative platform GitHub at
+`github.com/ncsl/seek <https://github.com/ncsl/seek>`_ and 
+`github.com/cronelab/ReconstructionVisualizer <https://github.com/cronelab/ReconstructionVisualizer>`_.
+
+.. image:: https://mne.tools/mne-bids/assets/GitHub.png
+   :width: 400
+   :alt: GitHub Logo
+   :target: https://github.com/cronelab/ReconstructionVisualizer
+
+
+Bug reports
+-----------
+
+Use the `GitHub issue tracker <https://github.com/cronelab/ReconstructionVisualizer/issues>`_
+to report bugs.
+
+Contributing code or documentation
+----------------------------------
+
+Please see our `contributing guide <https://github.com/cronelab/ReconstructionVisualizer/CONTRIBUTING.md>`_
+to find out how to get started.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,0 +1,32 @@
+:orphan:
+
+Installation
+============
+
+.. contents:: Contents
+   :local:
+   :depth: 2
+
+Dependencies
+------------
+
+TODO: list dependencies
+* ``mne`` (>=0.21)
+* ``numpy`` (>=1.14)
+* ``scipy`` (>=0.18.1)
+* ``nibabel`` (>=2.2, optional, for processing MRI data)
+* ``pybv`` (>=0.4, optional, for writing BrainVision data)
+* ``pandas`` (>=0.23.4, optional, for generating event statistics)
+* ``matplotlib`` (optional, for using the interactive data inspector)
+
+
+We recommend the `Docker <https://docs.docker.com/get-docker/>`_ 
+way of installing things because we rely on a plethora of open-source softwares 
+ranging languages and runtime environments. 
+
+We require that you use Python 3.6 or higher.
+
+Installation for ReconstructionVisualizer
+-----------------------------------------
+
+TODO: add installation instructions

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -1,0 +1,29 @@
+:orphan:
+
+Using ReconstructionVisualizer
+==============================
+
+.. contents:: Contents
+   :local:
+   :depth: 1
+
+Quickstart
+----------
+
+Command Line Interface
+~~~~~~~~~~~~~~~~~~~~~~
+
+Simply type TODO.
+
+Example:
+
+.. code-block:: bash
+
+  $ TODO
+
+
+.. _bidspath-intro:
+
+Mastering seek workflows
+------------------------
+TODO.

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -1,0 +1,52 @@
+:orphan:
+
+.. _whats_new:
+
+.. currentmodule:: reconstructionvisualizer
+
+What's new?
+===========
+
+.. currentmodule:: mne_bids
+.. _changes_0_1:
+
+Version 0.1 (unreleased)
+------------------------
+xxx
+
+.. contents:: Contents
+   :local:
+   :depth: 3
+
+Notable changes
+~~~~~~~~~~~~~~~
+xxx
+
+Authors
+~~~~~~~
+* `Christopher Coogan`_
+* `Adam Li`_
+
+Detailed list of changes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enhancements
+^^^^^^^^^^^^
+
+- The function :func:`mne_bids.print_dir_tree` has a new parameter ``return_str`` which allows it to return a str of the dir tree instead of printing it, by `Stefan Appelhoff`_ (`#600 <https://github.com/mne-tools/mne-bids/pull/600>`_)
+
+Bug fixes
+^^^^^^^^^
+- 
+
+API changes
+^^^^^^^^^^^
+- 
+
+Requirements
+^^^^^^^^^^^^
+- 
+
+:doc:`Find out what was new in previous releases <whats_new_previous_releases>`
+
+.. include:: authors.rst

--- a/docs/whats_new_previous_releases.rst
+++ b/docs/whats_new_previous_releases.rst
@@ -1,0 +1,63 @@
+:orphan:
+
+.. _whats_new_in_previous_releases:
+
+.. currentmodule:: reconstructionvisualizer
+
+What was new in previous releases?
+==================================
+
+.. contents:: Contents
+   :local:
+   :depth: 3
+
+.. currentmodule:: reconstructionvisualizer
+.. _changes_0_1:
+
+Version 0.1 (2020-10-22)
+------------------------
+
+TBD
+
+.. contents:: Contents
+   :local:
+   :depth: 3
+
+Notable changes
+~~~~~~~~~~~~~~~
+- TBD
+
+Authors
+~~~~~~~
+The following people have contributed to this release of reconstructionvisualizer:
+
+- `Adam Li`_
+- `Christopher Coogan`_
+
+Detailed list of changes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enhancements
+^^^^^^^^^^^^
+
+- 
+
+Bug fixes
+^^^^^^^^^
+
+- 
+
+API changes
+^^^^^^^^^^^
+
+In the transition to using `mne_bids.BIDSPath`, the following functions have been updated:
+
+- 
+The following functions have been removed:
+
+- 
+Further API changes:
+
+- 
+
+.. include:: authors.rst


### PR DESCRIPTION
Closes: #3 

Does not address details on mesh generator and visualizer. I think we should address some of the lower-hanging fruits first, such as the various TODO statements I left sprinkled in.

1. `whats_new` documents will track changes for releases for us to document the progression of improvements/bug fixes.
2. `contribute` documents will help us document the explicit developer workflow, which we still need a bit of work to consolidate how we use Docker/Python/Javascript/Snakemake/etc.
3. some github templates to make issues/PRs look more structured.

@TheBrainChain lmk wyt.